### PR TITLE
Fix get last index function

### DIFF
--- a/lib/squadster/schedules/services/create_lesson.ex
+++ b/lib/squadster/schedules/services/create_lesson.ex
@@ -18,7 +18,10 @@ defmodule Squadster.Schedules.Services.CreateLesson do
   end
 
   defp get_last_index(lessons) do
-    (lessons |> Enum.map(fn el -> el.index end) |> Enum.sort |> List.last) + 1
+    case lessons |> Enum.empty? do
+      true -> 1
+      false -> (lessons |> Enum.map(fn el -> el.index end) |> Enum.sort |> List.last) + 1
+    end
   end
 
   defp create(args) do


### PR DESCRIPTION
While I was showing crud to NVG, I found this bug, when we cannot create a lesson(first for a certain timetable) without specifying it's index.